### PR TITLE
Enabling Gallery Arrow coloring in Settings(.ini)

### DIFF
--- a/WP7/Gallery/Color/settings.ini
+++ b/WP7/Gallery/Color/settings.ini
@@ -349,7 +349,7 @@ X=340
 Y=17
 W=32
 H=16
-LeftMouseUpAction=!Execute ["#ADDONSPATH#RainRGB\RainRGB.exe" "VarName=arrowcolor" "FileName="#ROOTCONFIGPATH#Common\Color\color.inc"" "RefreshConfig=WP7\Gallery\Color"]
+LeftMouseUpAction=!Execute ["#ADDONSPATH#RainRGB\RainRGB.exe" "VarName=arrowcolor" "FileName=#ROOTCONFIGPATH#Common\Color\color.inc" "RefreshConfig=WP7\Gallery\Color"]
 MouseActionCursor=1
 ToolTipText=Arrow Color
 
@@ -473,7 +473,7 @@ X=245
 Y=4R
 MeterStyle=ico
 ImageName=#ROOTCONFIGPATH#Gallery\Tray\img\iconomexicano.png
-ToolTipText=¿Me extrañaste?
+ToolTipText=ï¿½Me extraï¿½aste?
 LeftMouseUpAction=!Execute ["#ROOTCONFIGPATH#Common\OmnimoApp.exe" Tray icon7 "#PROGRAMPATH#" "#SETTINGSPATH#" "#SKINSPATH#"]
 
 [ico8]


### PR DESCRIPTION
Changing color of the Gallery Arrow via Settings was previously impossible (for me, at least) due to misinterpreted quotation marks in [dot2]. Corrected it.
