### PR TITLE
Update interfacelift.ini

### DIFF
--- a/WP7/Panels/InterfaceLift/interfacelift.ini
+++ b/WP7/Panels/InterfaceLift/interfacelift.ini
@@ -40,7 +40,7 @@ Measure=Plugin
 Plugin=Plugins\WebParser.dll
 UpdateRate=#UpdateR#
 Url=#URL#
-RegExp="(?siU)class="preview">.*<a href="(.*)".*<img src="(.*)".*font-size: 18px;"><a href=".*">(.*)</a>.*<p>(.*)</p>"
+RegExp="(?siU)class="preview".*<a href="(.*)".*<img src="(.*)".*font-size: 16px;"><a href=".*">(.*)</a>.*<p>(.*)</p>"
 FinishAction=[!HideMeter LoadingText #CURRENTCONFIG#][!HideMeter LoadingBg #CURRENTCONFIG#][!Redraw]
 Substitute="/wallpaper/":"http://www.interfacelift.com/wallpaper/"
 


### PR DESCRIPTION
InterfaceLift has slightly updated their page structure and style - I've updated the RegExp to reflect this so that the panel will work again.
Changes:
1) ' class="preview">.\* ' -> 'class="preview".\* '
Their "preview" div now has a style attribute after the class attribute, so I removed the end carat to allow the RegExp to match the tag and ignore anything in the div after ' class="preview" '.
2)  ' font-size: 18px" -> "font-size: 16px '
They've changed the font size for the h1 to 16px.
