### PR TITLE
Fixed wrong free space percentage being shown.

### DIFF
--- a/WP7/Panels/HDD/Item4.ini
+++ b/WP7/Panels/HDD/Item4.ini
@@ -158,7 +158,7 @@ Text=#DriveLabel2#:\ %1%
 
 AutoScale=1
 Percentual=1
-MeasureName=MeasureHDD1
+MeasureName=MeasureHDD2
 FontSize=#defaultfontsize#*#ScaleDpi#
 X=(#height#/7-(5-#Padding#)*#scaledpi#)*#scaledpi#
 Y=(10*#scaledpi#)R


### PR DESCRIPTION
This far it always displayed the first one. 
Old:
![image](https://user-images.githubusercontent.com/39127254/83283520-a1a3d580-a1db-11ea-9748-6a7326129e8c.png)
New:
![image](https://user-images.githubusercontent.com/39127254/83283576-b8e2c300-a1db-11ea-8a4f-83d71e5baee3.png)
